### PR TITLE
Align MCP server version with package metadata

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -55,7 +55,7 @@ const leadsApi = new pipedrive.LeadsApi(apiClient);
 // Create MCP server
 const server = new McpServer({
   name: "pipedrive-mcp-server",
-  version: "1.0.0",
+  version: "1.0.2",
   capabilities: {
     resources: {},
     tools: {},


### PR DESCRIPTION
## Summary
- update the MCP server version string to 1.0.2 so it matches the published package metadata

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e81c47afcc8328b4677c7ca42cad5c