### PR TITLE
Derive MCP server version from package metadata

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,9 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { z } from "zod";
 import * as pipedrive from "pipedrive";
 import * as dotenv from 'dotenv';
-import { readFileSync } from 'fs';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
 
 // Type for error handling
 interface ErrorWithMessage {
@@ -55,11 +57,9 @@ const leadsApi = new pipedrive.LeadsApi(apiClient);
 
 function getServerVersion(): string {
   try {
-    const packageJson = JSON.parse(
-      readFileSync(new URL('../package.json', import.meta.url), 'utf-8')
-    ) as { version?: unknown };
+    const packageJson = require('../package.json') as { version?: unknown };
 
-    if (typeof packageJson.version === 'string') {
+    if (typeof packageJson.version === 'string' && packageJson.version.trim() !== '') {
       return packageJson.version;
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,9 +3,12 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { z } from "zod";
 import * as pipedrive from "pipedrive";
 import * as dotenv from 'dotenv';
-import { createRequire } from 'module';
+import { readFileSync } from 'fs';
+import { dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
 
-const require = createRequire(import.meta.url);
+const moduleDir = dirname(fileURLToPath(import.meta.url));
+const packageJsonPath = resolve(moduleDir, "../package.json");
 
 // Type for error handling
 interface ErrorWithMessage {
@@ -55,12 +58,26 @@ const pipelinesApi = new pipedrive.PipelinesApi(apiClient);
 const itemSearchApi = new pipedrive.ItemSearchApi(apiClient);
 const leadsApi = new pipedrive.LeadsApi(apiClient);
 
+let cachedVersion: string | null = null;
+
 function getServerVersion(): string {
+  if (cachedVersion) {
+    return cachedVersion;
+  }
+
+  const envVersion = process.env.npm_package_version;
+  if (typeof envVersion === 'string' && envVersion.trim() !== '') {
+    cachedVersion = envVersion.trim();
+    return cachedVersion;
+  }
+
   try {
-    const packageJson = require('../package.json') as { version?: unknown };
+    const packageJsonContent = readFileSync(packageJsonPath, "utf8");
+    const packageJson = JSON.parse(packageJsonContent) as { version?: unknown };
 
     if (typeof packageJson.version === 'string' && packageJson.version.trim() !== '') {
-      return packageJson.version;
+      cachedVersion = packageJson.version.trim();
+      return cachedVersion;
     }
 
     console.warn("Package version is missing or not a string; falling back to 'unknown'.");
@@ -68,7 +85,8 @@ function getServerVersion(): string {
     console.warn("Unable to read package.json for version information:", getErrorMessage(error));
   }
 
-  return 'unknown';
+  cachedVersion = 'unknown';
+  return cachedVersion;
 }
 
 // Create MCP server

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { z } from "zod";
 import * as pipedrive from "pipedrive";
 import * as dotenv from 'dotenv';
+import { readFileSync } from 'fs';
 
 // Type for error handling
 interface ErrorWithMessage {
@@ -52,10 +53,28 @@ const pipelinesApi = new pipedrive.PipelinesApi(apiClient);
 const itemSearchApi = new pipedrive.ItemSearchApi(apiClient);
 const leadsApi = new pipedrive.LeadsApi(apiClient);
 
+function getServerVersion(): string {
+  try {
+    const packageJson = JSON.parse(
+      readFileSync(new URL('../package.json', import.meta.url), 'utf-8')
+    ) as { version?: unknown };
+
+    if (typeof packageJson.version === 'string') {
+      return packageJson.version;
+    }
+
+    console.warn("Package version is missing or not a string; falling back to 'unknown'.");
+  } catch (error) {
+    console.warn("Unable to read package.json for version information:", getErrorMessage(error));
+  }
+
+  return 'unknown';
+}
+
 // Create MCP server
 const server = new McpServer({
   name: "pipedrive-mcp-server",
-  version: "1.0.0",
+  version: getServerVersion(),
   capabilities: {
     resources: {},
     tools: {},


### PR DESCRIPTION
## Summary
- read package.json at runtime to derive the MCP server version string dynamically
- warn and fall back to "unknown" if the package metadata cannot be read or is invalid

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e81c47afcc8328b4677c7ca42cad5c